### PR TITLE
Remove custom views on re-used annotations before adding new ones.

### DIFF
--- a/Pod/Classes/DXAnnotationView.m
+++ b/Pod/Classes/DXAnnotationView.m
@@ -33,6 +33,9 @@
         [self validateSettings:settings];
         _hasCalloutView = (calloutView) ? YES : NO;
         self.canShowCallout = NO;
+        
+        if (self.pinView != nil) { [self.pinView removeFromSuperview]; }
+        if (self.calloutView != nil) { [self.calloutView removeFromSuperview]; }
 
         self.pinView = pinView;
         self.pinView.userInteractionEnabled = YES;


### PR DESCRIPTION
When using custom views, recycling the pins leaves hidden subviews around. This causes poor map performance over time. This PR removes the old views first, so they are cleaned up correctly. 

It's especially noticeable while using clustering algorithms, since the pins are added and removed from the map frequently as you zoom.